### PR TITLE
Add reveal class to results section

### DIFF
--- a/website Omnia v2.html
+++ b/website Omnia v2.html
@@ -809,7 +809,7 @@
       </div>
     </section>
 
-    <section class="container band results-bg" id="results">
+    <section class="container band results-bg reveal" id="results">
       <h2 class="reveal">Results</h2>
       <p class="muted reveal" style="margin-top:-6px">Vizualizari simple pentru alocare si randamente. Public vs gated.</p>
       <div class="panel reveal" role="img" aria-label="Distribuție pe sectoare" style="margin-top:16px">


### PR DESCRIPTION
## Summary
- add the `reveal` class to the Results section so it participates in the intersection observer animations

## Testing
- browser_container.run_playwright_script (visual verification of bar widths)


------
https://chatgpt.com/codex/tasks/task_e_68c94d5e55b483208c7c18ed777da31f